### PR TITLE
Explicitly set `localhost` when loading dumps

### DIFF
--- a/django_dbdev/backends/postgres.py
+++ b/django_dbdev/backends/postgres.py
@@ -145,7 +145,7 @@ class PostgresBackend(BaseDbdevBackend):
         if dumpfile.endswith('.dump'):
             print(self.pg_restore(dumpfile))
         else:
-            self.psql(self.dbsettings['NAME'], f=dumpfile)
+            self.psql(self.dbsettings['NAME'], f=dumpfile, h="localhost")
 
     def create_dbdump(self, dumpfile):
         #args = ['-f', dumpfile, '-a', '--column-inserts']


### PR DESCRIPTION
The problem occurs when the default are modified. Sockets can't be
created in `/var/run` as the permissions are wrong, so we can patch the
`unix_socket_directory` to something else. This works for most commands
as they will reference the data directory, but `psql` does not. It
will only look for the socket in `/var/run`, so we explicitly set the
hostname to avoid the unix socket lookup.

Another solution is to pass `PGHOST` into the shell executing `psql`, but didn't 
take a hard look at how to do that.